### PR TITLE
Add ability to send test alerts from alert rules

### DIFF
--- a/apps/app-worker/src/routes/app/notifications.tsx
+++ b/apps/app-worker/src/routes/app/notifications.tsx
@@ -3,7 +3,7 @@ import { Await, createFileRoute, defer } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 
 import { Card, CardTitle, Page, PageHeader } from "@/components/layout";
-import { ErrorCard } from "@/components/feedback";
+import { ErrorCard, SuccessBox } from "@/components/feedback";
 import { TabNav } from "@/components/navigation";
 import { ListContainer, ListRow } from "@/components/list";
 import { NotificationsModals } from "@/components/modals/notifications";
@@ -25,6 +25,7 @@ import {
   deleteAlertRuleFn,
   toggleAlertRuleFn,
   listNotificationDeliveryAttemptsFn,
+  sendTestAlertRuleFn,
 } from "@/server/functions/alert-rules";
 
 type Monitor = {
@@ -148,6 +149,8 @@ export default function Notifications() {
   const [isRuleContextLoaded, setIsRuleContextLoaded] = useState(false);
   const [rules, setRules] = useState<AlertRule[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [testingRuleId, setTestingRuleId] = useState<string | null>(null);
 
   const [isChannelModalOpen, setIsChannelModalOpen] = useState(false);
   const [isRuleModalOpen, setIsRuleModalOpen] = useState(false);
@@ -157,6 +160,7 @@ export default function Notifications() {
 
   const deleteRule = useServerFn(deleteAlertRuleFn);
   const toggleRule = useServerFn(toggleAlertRuleFn);
+  const sendTestAlert = useServerFn(sendTestAlertRuleFn);
   const listRules = useServerFn(listAlertRulesFn);
 
   const refreshChannels = async () => {
@@ -216,6 +220,22 @@ export default function Notifications() {
     }
   };
 
+  const onSendTestAlert = async (id: string) => {
+    setError(null);
+    setSuccess(null);
+    setTestingRuleId(id);
+    try {
+      const res = await sendTestAlert({ data: { id } });
+      setSuccess(
+        `Queued test alert ${res.alertId}. Check the channel and the audit log for delivery status.`
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTestingRuleId(null);
+    }
+  };
+
   const getChannelDisplay = (channel: Channel) => {
     const config = JSON.parse(channel.configJson);
     if (channel.type === "email") {
@@ -271,6 +291,11 @@ export default function Notifications() {
       </PageHeader>
 
       {error && <ErrorCard message={error} />}
+      {success && (
+        <SuccessBox title="Test alert queued">
+          <p className="muted mb-0">{success}</p>
+        </SuccessBox>
+      )}
 
       <TabNav
         tabs={[
@@ -293,7 +318,7 @@ export default function Notifications() {
               const display = getChannelDisplay(channel);
               return (
                 <ListRow
-                   isOdd={index > 0}
+                  isOdd={index > 0}
                   key={channel.id}
                   titleClassName="flex flex-wrap items-center gap-2"
                   title={
@@ -340,7 +365,7 @@ export default function Notifications() {
                   config.label || config.url || config.to || "Channel";
                 return (
                   <ListRow
-                     isOdd={index > 0}
+                    isOdd={index > 0}
                     key={rule.id}
                     title={
                       <>
@@ -393,6 +418,15 @@ export default function Notifications() {
                         <Button
                           type="button"
                           variant="outline"
+                          color="info"
+                          disabled={testingRuleId === rule.id}
+                          onClick={() => onSendTestAlert(rule.id)}
+                        >
+                          {testingRuleId === rule.id ? "Sending…" : "Send test"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
                           color={rule.enabled ? "warning" : "success"}
                           onClick={() => onToggleRule(rule.id, !rule.enabled)}
                         >
@@ -431,7 +465,7 @@ export default function Notifications() {
                         return (
                           <ListRow
                             key={rule.id}
-                             isOdd={index > 0}
+                            isOdd={index > 0}
                             title={
                               <>
                                 <span

--- a/apps/app-worker/src/server/functions/alert-rules.ts
+++ b/apps/app-worker/src/server/functions/alert-rules.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { env } from "cloudflare:workers";
 import { z } from "zod";
-import { getDb } from "@bitwobbly/shared";
+import { getDb, randomId } from "@bitwobbly/shared";
 
 import {
   listAlertRules,
@@ -253,6 +253,33 @@ export const toggleAlertRuleFn = createServerFn({ method: "POST" })
     const db = getDb(vars.DB);
     await toggleAlertRule(db, teamId, data.id, data.enabled);
     return { ok: true };
+  });
+
+export const sendTestAlertRuleFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { id: string }) => data)
+  .handler(async ({ data }) => {
+    const { teamId } = await requireTeam();
+    const vars = env;
+    const db = getDb(vars.DB);
+    const rule = await getAlertRuleById(db, teamId, data.id);
+    if (!rule) throw new Error("Alert rule not found");
+
+    const channelExists = await notificationChannelExists(
+      db,
+      teamId,
+      rule.channelId
+    );
+    if (!channelExists) throw new Error("Notification channel not found");
+
+    const alertId = randomId("al");
+    await vars.ALERT_JOBS.send({
+      type: "test",
+      alert_id: alertId,
+      team_id: teamId,
+      rule_id: rule.id,
+    });
+
+    return { ok: true, alertId };
   });
 
 export const listAlertRuleFiresFn = createServerFn({ method: "GET" })

--- a/apps/notifier-worker/src/index.ts
+++ b/apps/notifier-worker/src/index.ts
@@ -2,19 +2,20 @@ import type {
   AlertJob,
   MonitorAlertJob,
   IssueAlertJob,
+  TestAlertJob,
 } from "@bitwobbly/shared";
 import { isAlertJob, createLogger, serialiseError } from "@bitwobbly/shared";
 import { withSentry } from "@sentry/cloudflare";
 
 import type { Env } from "./types/env";
 import { assertEnv } from "./types/env";
-import { sendAlertEmail, sendIssueAlertEmail } from "./lib/email";
-import { getDb } from "@bitwobbly/shared";
 import {
-  handleStatusPageJob,
-  isStatusPageJob,
-  type StatusPageJob,
-} from "./lib/status-page-jobs";
+  sendAlertEmail,
+  sendIssueAlertEmail,
+  sendTestAlertEmail,
+} from "./lib/email";
+import { getDb } from "@bitwobbly/shared";
+import { handleStatusPageJob, isStatusPageJob } from "./lib/status-page-jobs";
 import {
   getAlertRuleById,
   getChannelById,
@@ -53,6 +54,8 @@ const handler = {
 
           if (job.type === "issue") {
             await handleIssueAlert(job, env, db);
+          } else if (job.type === "test") {
+            await handleTestAlert(job, env, db);
           } else {
             await handleMonitorAlert(job, env, db);
           }
@@ -90,6 +93,95 @@ export default withSentry<Env, AlertJob>(
   }),
   handler
 );
+
+async function handleTestAlert(
+  job: TestAlertJob,
+  env: Env,
+  db: ReturnType<typeof getDb>
+) {
+  const rule = await getAlertRuleById(db, job.rule_id);
+  if (!rule) {
+    logger.warn("alert rule not found", { ruleId: job.rule_id });
+    return;
+  }
+
+  const channel = await getChannelById(db, rule.channelId);
+  if (!channel) {
+    logger.warn("notification channel not found or disabled", {
+      channelId: rule.channelId,
+    });
+    return;
+  }
+
+  let cfg: unknown = null;
+  try {
+    cfg = JSON.parse(channel.configJson);
+  } catch {
+    logger.warn("invalid channel config", { channelType: channel.type });
+    return;
+  }
+
+  const auditContext: DeliveryAuditContext = {
+    teamId: job.team_id,
+    alertId: job.alert_id,
+    ruleId: job.rule_id,
+    channelId: channel.id,
+    channelType: channel.type,
+    recipient:
+      channel.type === "webhook"
+        ? ((cfg as { url?: string }).url ?? null)
+        : ((cfg as { to?: string }).to ?? null),
+    provider: channel.type === "webhook" ? "webhook" : "resend",
+    sourceType: "test",
+    triggerType: "test_alert",
+    monitorId: rule.monitorId,
+    details: {
+      ruleName: rule.name,
+      ruleSourceType: rule.sourceType,
+      ruleTriggerType: rule.triggerType,
+    },
+  };
+
+  if (channel.type === "webhook") {
+    try {
+      await sendWebhook(cfg as { url?: string }, {
+        alert_id: job.alert_id,
+        type: "test",
+        rule_id: job.rule_id,
+        rule_name: rule.name,
+        rule_source_type: rule.sourceType,
+        rule_trigger_type: rule.triggerType,
+        message: "This is a BitWobbly test alert.",
+        ts: new Date().toISOString(),
+      });
+      await recordDeliverySent(db, auditContext);
+    } catch (error: unknown) {
+      await recordDeliveryFailed(db, auditContext, error);
+      throw error;
+    }
+  } else if (channel.type === "email") {
+    const emailConfig = cfg as { to?: string; from?: string; subject?: string };
+    const to = emailConfig.to;
+    if (!to) return;
+
+    try {
+      const result = await sendTestAlertEmail({
+        email: to,
+        alertId: job.alert_id,
+        ruleName: rule.name,
+        triggerType: rule.triggerType,
+        sourceType: rule.sourceType,
+        from: emailConfig.from,
+        subjectPrefix: emailConfig.subject,
+        resendApiKey: env.RESEND_API_KEY,
+      });
+      await recordDeliverySent(db, auditContext, result);
+    } catch (error: unknown) {
+      await recordDeliveryFailed(db, auditContext, error);
+      throw error;
+    }
+  }
+}
 
 async function handleMonitorAlert(
   job: MonitorAlertJob,

--- a/apps/notifier-worker/src/lib/email.ts
+++ b/apps/notifier-worker/src/lib/email.ts
@@ -43,9 +43,91 @@ export interface SendIssueAlertEmailParams {
   resendApiKey: string;
 }
 
+export interface SendTestAlertEmailParams {
+  email: string;
+  alertId: string;
+  ruleName: string;
+  triggerType: string;
+  sourceType: string;
+  from?: string;
+  subjectPrefix?: string;
+  resendApiKey: string;
+}
+
 export interface EmailDeliveryResult {
   subject: string;
   providerMessageId: string | null;
+}
+
+export async function sendTestAlertEmail({
+  email,
+  alertId,
+  ruleName,
+  triggerType,
+  sourceType,
+  from,
+  subjectPrefix,
+  resendApiKey,
+}: SendTestAlertEmailParams): Promise<EmailDeliveryResult> {
+  const safeAlertId = escapeHtml(alertId);
+  const safeRuleName = escapeHtml(ruleName);
+  const safeTriggerType = escapeHtml(triggerType);
+  const safeSourceType = escapeHtml(sourceType);
+  const subject = `${subjectPrefix?.trim() || "BitWobbly Alert"} - Test alert`;
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${resendApiKey}`,
+    },
+    body: JSON.stringify({
+      from: normaliseFromAddress(from),
+      to: [email],
+      subject,
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>BitWobbly Test Alert</title>
+          </head>
+          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: #0d6efd; padding: 20px; border-radius: 8px; margin-bottom: 20px; color: white;">
+              <h1 style="margin: 0;">BitWobbly Test Alert</h1>
+              <p style="margin: 10px 0 0 0; font-size: 14px; opacity: 0.9;">Your notification rule delivered this test successfully.</p>
+            </div>
+
+            <div style="background: white; padding: 20px; border-radius: 8px; border: 1px solid #dee2e6;">
+              <h2 style="margin-top: 0; color: #495057;">Rule Details</h2>
+              <p><strong>Rule:</strong> ${safeRuleName}</p>
+              <p><strong>Source:</strong> ${safeSourceType}</p>
+              <p><strong>Trigger:</strong> ${safeTriggerType}</p>
+              <p><strong>Alert ID:</strong> ${safeAlertId}</p>
+              <p><strong>Time:</strong> ${new Date().toLocaleString()}</p>
+            </div>
+
+            <div style="margin-top: 20px; padding: 20px; background: #e9ecef; border-radius: 8px;">
+              <p style="margin: 0; font-size: 14px; color: #495057;">
+                This test alert was generated from your BitWobbly notification rule.
+              </p>
+            </div>
+          </body>
+        </html>
+      `,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to send email: ${error}`);
+  }
+
+  return {
+    subject,
+    providerMessageId: await getProviderMessageId(response),
+  };
 }
 
 export async function sendIssueAlertEmail({
@@ -261,7 +343,9 @@ export async function sendAlertEmail({
   };
 }
 
-async function getProviderMessageId(response: Response): Promise<string | null> {
+async function getProviderMessageId(
+  response: Response
+): Promise<string | null> {
   const contentType = response.headers.get("content-type") || "";
   if (!contentType.includes("application/json")) return null;
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -35,6 +35,13 @@ export interface MonitorAlertJob {
   incident_id?: string;
 }
 
+export interface TestAlertJob {
+  type: "test";
+  alert_id: string;
+  team_id: string;
+  rule_id: string;
+}
+
 export interface IssueAlertJob {
   type: "issue";
   alert_id: string;
@@ -50,7 +57,7 @@ export interface IssueAlertJob {
   environment?: string;
 }
 
-export type AlertJob = MonitorAlertJob | IssueAlertJob;
+export type AlertJob = MonitorAlertJob | IssueAlertJob | TestAlertJob;
 
 export type AlertTriggerType =
   | "new_issue"
@@ -123,9 +130,11 @@ export function isAlertJob(value: unknown): value is AlertJob {
   if (typeof job.team_id !== "string") return false;
 
   if (job.type === "monitor") {
-    return (
-      typeof job.rule_id === "string" && typeof job.monitor_id === "string"
-    );
+    return typeof job.monitor_id === "string";
+  }
+
+  if (job.type === "test") {
+    return typeof job.rule_id === "string";
   }
 
   if (job.type === "issue") {


### PR DESCRIPTION
### Motivation

- Provide a way for teams to verify that an alert rule and its notification channel are configured correctly by queuing a test notification.  
- Ensure test deliveries are routed through the existing notifier pipeline so deliveries are auditable and exercised the same code paths as real alerts.  

### Description

- Add a server endpoint `sendTestAlertRuleFn` (in `apps/app-worker/src/server/functions/alert-rules.ts`) that validates team ownership and channel existence, creates a test `alert_id`, and enqueues a `type: "test"` job to the `ALERT_JOBS` queue.  
- Introduce a `TestAlertJob` type in shared types and update `isAlertJob` to recognize test jobs (`packages/shared/src/types/index.ts`) so workers accept queued test alerts.  
- Extend the notifier worker (`apps/notifier-worker/src/index.ts`) with `handleTestAlert` to deliver test payloads to webhook channels or send a dedicated test email via `sendTestAlertEmail`, and reuse existing delivery-audit recording (`recordDeliverySent` / `recordDeliveryFailed`).  
- Add `sendTestAlertEmail` (in `apps/notifier-worker/src/lib/email.ts`) to produce a clear test message with rule/trigger/alert id metadata, and add a `Send test` button and success feedback to the notifications UI (`apps/app-worker/src/routes/app/notifications.tsx`) with per-rule loading state.  

### Testing

- Ran TypeScript checks: `pnpm -C packages/shared typecheck && pnpm -C apps/app-worker typecheck && pnpm -C apps/notifier-worker typecheck`, which completed successfully.  
- Ran targeted ESLint on modified files via `pnpm exec eslint packages/shared/src/types/index.ts apps/app-worker/src/server/functions/alert-rules.ts apps/notifier-worker/src/lib/email.ts apps/notifier-worker/src/index.ts apps/app-worker/src/routes/app/notifications.tsx`, which completed successfully (no errors in the modified files).  
- Ran `git diff --check` to confirm no whitespace/diff issues, which passed.  
- Note: `pnpm lint` (full repo lint) still reports unrelated pre-existing lint issues elsewhere in the repo; these are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ac1c3a58832aa91578ec312d2964)