### PR TITLE
Make AI assistant floating button icon-only and right-aligned with light outline

### DIFF
--- a/apps/app-worker/src/components/assistant/FloatingAiAssistant.tsx
+++ b/apps/app-worker/src/components/assistant/FloatingAiAssistant.tsx
@@ -134,8 +134,40 @@ export function FloatingAiAssistant() {
           </div>
         </div>
       ) : (
-        <Button type="button" onClick={() => setIsOpen(true)}>
-          AI Assistant
+        <Button
+          type="button"
+          variant="outline"
+          className="assistant-fab-button"
+          onClick={() => setIsOpen(true)}
+          aria-label="Open AI operations assistant"
+          title="Open AI operations assistant"
+        >
+          <svg
+            className="assistant-fab-icon"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 3.75L13.72 8.28L18.25 10L13.72 11.72L12 16.25L10.28 11.72L5.75 10L10.28 8.28L12 3.75Z"
+              stroke="currentColor"
+              strokeWidth="1.7"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M18.25 14.25L19.03 16.22L21 17L19.03 17.78L18.25 19.75L17.47 17.78L15.5 17L17.47 16.22L18.25 14.25Z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M5.75 14.75H9.25C10.08 14.75 10.75 15.42 10.75 16.25V18.25C10.75 19.08 10.08 19.75 9.25 19.75H6.75L4.25 21V16.25C4.25 15.42 4.92 14.75 5.75 14.75Z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinejoin="round"
+            />
+          </svg>
         </Button>
       )}
     </div>

--- a/apps/app-worker/src/styles.css
+++ b/apps/app-worker/src/styles.css
@@ -1431,6 +1431,31 @@ textarea {
   right: 16px;
   bottom: 16px;
   z-index: 50;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.assistant-fab-button {
+  width: 3.25rem;
+  height: 3.25rem;
+  padding: 0 !important;
+  border: 1.5px solid var(--primary) !important;
+  border-radius: 999px !important;
+  background: rgba(255, 255, 255, 0.92) !important;
+  color: var(--primary-dark) !important;
+  box-shadow: var(--shadow);
+  display: inline-grid;
+  place-items: center;
+}
+
+.assistant-fab-button:hover:not(:disabled) {
+  background: #fff7ef !important;
+  color: var(--primary) !important;
+}
+
+.assistant-fab-icon {
+  width: 1.65rem;
+  height: 1.65rem;
 }
 
 .assistant-panel {
@@ -1879,13 +1904,13 @@ textarea {
 
 @media (max-width: 640px) {
   .assistant-fab-wrapper {
-    left: 8px;
+    left: auto;
     right: 8px;
     bottom: 8px;
   }
 
   .assistant-panel {
-    width: 100%;
+    width: min(calc(100vw - 16px), 32rem);
     height: calc(100dvh - 16px);
     max-height: calc(100dvh - 16px);
   }


### PR DESCRIPTION
### Motivation
- The floating AI assistant should always sit on the right side, use an icon instead of a text label, and have a light background with a primary outline rather than a primary-filled background for a subtler, accessible launcher.

### Description
- Replaced the text launcher with an icon-only outline button in `apps/app-worker/src/components/assistant/FloatingAiAssistant.tsx`, adding `aria-label` and `title` for accessibility and an inline SVG icon.
- Added the `.assistant-fab-button` and `.assistant-fab-icon` styles and adjusted `.assistant-fab-wrapper` in `apps/app-worker/src/styles.css` to enforce right alignment and an outlined/light background visual treatment.
- Updated mobile layout to keep the launcher on the right (`left: auto; right: 8px`) and constrained the opened panel width to the viewport (`width: min(calc(100vw - 16px), 32rem)`).

### Testing
- Ran `pnpm -C apps/app-worker typecheck`, which completed successfully. 
- Ran ESLint on the modified files with `pnpm -C apps/app-worker exec eslint src/components/assistant/FloatingAiAssistant.tsx src/styles.css`, which completed; ESLint reported a CSS warning about no matching configuration. 
- Attempted to start the dev server with `pnpm -C apps/app-worker dev --host 127.0.0.1`, which failed due to the environment requiring Wrangler remote login (unrelated to these UI changes). 
- Noted an earlier unrelated route-generation/type mismatch in a separate run that caused `pnpm -C apps/app-worker build` to fail in that context; this is pre-existing and not caused by the assistant changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024ddf8144832a92934dacc9a21a95)