### PR TITLE
fix(shared): parse AI action worker queue payloads

### DIFF
--- a/packages/shared/src/ai/__tests__/action-schemas.test.ts
+++ b/packages/shared/src/ai/__tests__/action-schemas.test.ts
@@ -5,6 +5,7 @@ import {
   classifyTeamAiActionGate,
   parseAiActionTriggerEvent,
   parseStrictTeamAiActionPlan,
+  parseAiActionWorkerMessage,
   shouldAllowEgress,
 } from "../action-schemas.ts";
 
@@ -30,6 +31,29 @@ test("parseStrictTeamAiActionPlan extracts JSON from fenced model output", () =>
 
   assert.equal(plan.summary, "Plan looks good");
   assert.equal(plan.actions[0].actionType, "monitor_tuning");
+});
+
+test("parseAiActionWorkerMessage parses structured queue payload", () => {
+  const payload = `{\"kind\":\"trigger\",\"trigger\":{\"id\":\"evt_1\",\"source\":\"monitor_transition\",\"type\":\"monitor_down\",\"teamId\":\"team_1\",\"occurredAt\":\"2026-01-01T00:00:00.000Z\",\"idempotencyKey\":\"monitor_down_1\"}}`;
+  const parsed = parseAiActionWorkerMessage(payload);
+  assert.equal(parsed.kind, "trigger");
+});
+
+test("parseAiActionWorkerMessage parses queued command payload", () => {
+  const payload = {
+    kind: "command",
+    command: {
+      id: "acmd_1",
+      teamId: "team_1",
+      actionId: "action_1",
+      operation: "approve",
+      requestedByUserId: "user_1",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+  const parsed = parseAiActionWorkerMessage(payload);
+  assert.equal(parsed.kind, "command");
+  assert.equal(parsed.command.operation, "approve");
 });
 
 test("classifyTeamAiActionGate blocks by explicit policy blocklist", () => {

--- a/packages/shared/src/ai/action-schemas.ts
+++ b/packages/shared/src/ai/action-schemas.ts
@@ -203,7 +203,11 @@ export function parseAiActionCommandEvent(value: unknown): AiActionCommandEvent 
 }
 
 export function parseAiActionWorkerMessage(value: unknown): AiActionWorkerMessage {
-  return AiActionWorkerMessageSchema.parse(value);
+  const parsedValue =
+    typeof value === "string"
+      ? JSON.parse(value.trim())
+      : value;
+  return AiActionWorkerMessageSchema.parse(parsedValue);
 }
 
 function extractLikelyJsonText(input: string): string {


### PR DESCRIPTION
## Issue
AI action worker message parsing in shared schemas assumed queue bodies were already objects, which can fail if queue transport serializes message payloads as strings.

## Why this matters
A malformed dispatch format prevents the AI sandbox from consuming action jobs and can silently block automation workflows that rely on action triggers or commands.

## Changes
- Added string-safe parsing path in `parseAiActionWorkerMessage` in shared contracts.
- Reused existing Zod schema validation after parsing.
- Added tests for trigger and command queue payloads in `packages/shared/src/ai/__tests__/action-schemas.test.ts`.

## Validation
- `pnpm --filter @bitwobbly/shared test --silent`
- `pnpm --filter @bitwobbly/shared typecheck`

## Impact
Improves producer/consumer resilience without changing runtime semantics.
