### PR TITLE
Fix app-worker modal keyboard focus and focus trap

### DIFF
--- a/apps/app-worker/src/components/Modal.tsx
+++ b/apps/app-worker/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 
 interface ModalProps {
   isOpen: boolean;
@@ -8,6 +8,62 @@ interface ModalProps {
 }
 
 export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedElement.current = document.activeElement as HTMLElement | null;
+    const firstFocusable =
+      dialogRef.current?.querySelector<HTMLElement>(
+        'a[href], button, textarea, input, select, details, [tabindex]:not([tabindex="-1"])'
+      );
+
+    if (firstFocusable) {
+      firstFocusable.focus();
+    } else {
+      dialogRef.current?.focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'a[href], button, textarea, input, select, details, [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusableElements?.length) return;
+
+      const items = Array.from(focusableElements).filter((element) => !element.hasAttribute("disabled"));
+      if (!items.length) return;
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedElement.current?.focus();
+    };
+  }, [isOpen, onClose]);
+
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
@@ -20,20 +76,10 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
   }, [isOpen]);
 
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("keydown", handleEscape);
+    if (isOpen && dialogRef.current) {
+      dialogRef.current.focus();
     }
-
-    return () => {
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -41,13 +87,17 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
     <div className="modal-overlay" onClick={onClose}>
       <div
         className="modal-content"
+        ref={dialogRef}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-labelledby={titleId}
+        tabIndex={-1}
       >
         <div className="modal-header">
-          <h3 className="modal-title">{title}</h3>
+          <h3 className="modal-title" id={titleId}>
+            {title}
+          </h3>
           <button
             type="button"
             className="modal-close"


### PR DESCRIPTION
## Issue
Modal dialogs in app-worker lacked keyboard focus management, allowing focus to escape the dialog while it is open.

## Impacted flow
Any route that opens a shared modal (monitors, projects, issues, settings, team management) can trap keyboard users outside modal context unexpectedly.

## Recommendation implemented
- Focus the first interactive element when modal opens and restore the previous focus target after close.
- Add a Tab/Shift+Tab focus trap to keep keyboard focus inside the dialog.
- Keep Escape handling in dialog context and switch to `aria-labelledby` linkage for title semantics.

## Validation
- `pnpm -C apps/app-worker test`
- `pnpm -C apps/app-worker typecheck`
